### PR TITLE
Remove ensureIndex from MongoLock constructor.

### DIFF
--- a/spec/Onebip/Concurrency/MongoLockTest.php
+++ b/spec/Onebip/Concurrency/MongoLockTest.php
@@ -15,6 +15,8 @@ class MongoLockTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $this->lockCollection = (new MongoClient())->test->lock;
+        MongoLock::ensureIndex($this->lockCollection);
+
         $this->clock = Phake::mock('Onebip\Clock');
 
         $this->slept = [];
@@ -26,6 +28,24 @@ class MongoLockTest extends \PHPUnit_Framework_TestCase
     public function tearDown()
     {
         $this->lockCollection->drop();
+    }
+
+    /**
+     * @expectedException Onebip\Concurrency\LockUniqueIndexNotAvailable
+     * @expectedExceptionMessage ws-a-30:32 collection `lock` is missing indexes, see MongoLock::ensureIndex
+     */
+    public function testErrorWhenIndexIsNotPresent()
+    {
+        $this->lockCollection->deleteIndexes();
+
+        $lock = new MongoLock(
+            $this->lockCollection,
+            'windows_defrag',
+            'ws-a-30:32',
+            $this->clock
+        );
+
+        $lock->acquire();
     }
 
     public function testALockCanBeAcquired()
@@ -254,7 +274,7 @@ class MongoLockTest extends \PHPUnit_Framework_TestCase
                 return true;
             })
             ->then(function($sequencesOfSteps) {
-                $this->lockCollection->drop();
+                $this->lockCollection->remove();
                 $log = "/tmp/mongolock_{$this->iteration}.log";
                 if (file_exists($log)) {
                     unlink($log);

--- a/src/Onebip/Concurrency/LockUniqueIndexNotAvailable.php
+++ b/src/Onebip/Concurrency/LockUniqueIndexNotAvailable.php
@@ -1,0 +1,8 @@
+<?php
+namespace Onebip\Concurrency;
+
+use RuntimeException;
+
+class LockUniqueIndexNotAvailable extends RuntimeException
+{
+}

--- a/src/Onebip/Concurrency/MongoLock.php
+++ b/src/Onebip/Concurrency/MongoLock.php
@@ -18,7 +18,6 @@ class MongoLock implements Lock
     public function __construct(MongoCollection $collection, $programName, $processName, $clock = null, $sleep = 'sleep')
     {
         $this->collection = $collection;
-        $this->collection->ensureIndex(['program' => 1], ['unique' => true]);
         $this->programName = $programName;
         $this->processName = $processName;
         if ($clock === null) {

--- a/src/Onebip/Concurrency/MongoLockRepository.php
+++ b/src/Onebip/Concurrency/MongoLockRepository.php
@@ -12,6 +12,11 @@ class MongoLockRepository
         $this->collection = $collection;
     }
 
+    public function ensureIndex()
+    {
+        MongoLock::ensureIndex($this->collection);
+    }
+
     // TODO: expose only not expired locks
     public function all()
     {


### PR DESCRIPTION
This causes major issues when the lock is written to a replicaSet: somehow it puts a great deal of pressure on it.

This patch removes the `ensureIndex` that keeps banging at a primary's door, while still checking wether the index (which is vital) is present or not before lock acquirement.
